### PR TITLE
fixed test_path and train_path arguments bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Project Architecture :
 		|- Bag.py 
 
 
-	:~$ python Bag.py --train_set images/train/ --test_set images/test/
+	:~$ python Bag.py --train_path images/train/ --test_path images/test/
 
 
 


### PR DESCRIPTION
File "Bag.py", in 140, 141:
parser.add_argument('--train_path', action="store", dest="train_path", required=True)
parser.add_argument('--test_path', action="store", dest="test_path", required=True)
but in the instruction README.md file, it shows:
python Bag.py --train_set images/train/ --test_set images/test/

Need to change 'python Bag.py --train_set images/train/ --test_set images/test/' to 'python Bag.py --train_path images/train/ --test_path images/test/' in README.md to make to work properly.